### PR TITLE
Making slicer code compatible with python 3+ and some reformatting 

### DIFF
--- a/laser_slicer.py
+++ b/laser_slicer.py
@@ -23,72 +23,79 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import argparse
 import os
-import tempfile
 import subprocess
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-            description='Slice a 3D model into a vector file for laser cutting' );
-    parser.add_argument( '--input',
-            metavar = 'input_file',
-            type = str,
-            required = True,
-            help = 'Input file path' )
-    parser.add_argument( '--end-height',
-            metavar = 'mm',
-            type = float,
-            required = True,
-            dest = 'end_height',
-            help = 'Stop slicing at a given height, in mm' )
-    parser.add_argument( '--layer-height',
-            metavar = 'mm',
-            type = float,
-            required = True,
-            dest = 'layer_height',
-            help = 'Height of each layer' )
-    parser.add_argument( '--output-type',
-            metavar = 'output_type',
-            type = str,
-            default = 'dxf',
-            dest = 'output_type',
-            choices = [ 'svg', 'dxf' ],
-            help = 'Output file type' )
-    parser.add_argument( '--start-height',
-            metavar = 'mm',
-            default = 0.1,
-            type = float,
-            dest = 'start_height',
-            help = 'Start slicing at a given height, in mm' )
-    args = parser.parse_args()
-    return args
+            description='Slice a 3D model into a vector file for laser cutting')
+    parser.add_argument('--input',
+                        metavar='input_file',
+                        type=str,
+                        required=True,
+                        help='Input file path')
 
-def get_scad_tmp_file():
-    scad_file = tempfile.NamedTemporaryFile( delete = False )
-    scad_file_name = scad_file.name
-    scad_file.close()
-    return scad_file_name
+    parser.add_argument('--end-height',
+                        metavar='mm',
+                        type=float,
+                        required=True,
+                        dest='end_height',
+                        help='Stop slicing at a given height, in mm')
+
+    parser.add_argument('--layer-height',
+                        metavar='mm',
+                        type=float,
+                        required=True,
+                        dest='layer_height',
+                        help='Height of each layer')
+
+    parser.add_argument('--output-type',
+                        metavar='output_type',
+                        type=str,
+                        default='dxf',
+                        dest='output_type',
+                        choices=['svg', 'dxf'],
+                        help='Output file type')
+
+    parser.add_argument('--start-height',
+                        metavar='mm',
+                        default=0.1,
+                        type=float,
+                        dest='start_height',
+                        help='Start slicing at a given height, in mm')
+
+    arguments = parser.parse_args()
+
+    return arguments
+
+
+def get_scad_temp_file(input_file):
+    scad_file_path = os.path.dirname(os.path.abspath(__file__))
+    temp_scad_file_name = os.path.join(scad_file_path, input_file+'temp')
+    return temp_scad_file_name
+
 
 def slice_model(
     output_type,
     model_name,
-    tmp_file,
     start_height,
     layer_height,
     end_height
 ):
+    scad_temp_file = get_scad_temp_file(model_name)
     current_layer_height = start_height
     layer_count = 1
-    while( current_layer_height < end_height ):
-        print "Creating layer " + str( layer_count ) + " at height " + str( current_layer_height )
+    while current_layer_height < end_height:
+        print("Creating layer " + str(layer_count) + " at height " + str(current_layer_height))
         create_slice(
-                output_type = output_type,
-                model_name = model_name,
-                tmp_file = tmp_file,
-                slice_height = current_layer_height,
-                layer_count = layer_count )
+                output_type=output_type,
+                model_name=model_name,
+                tmp_file=scad_temp_file,
+                slice_height=current_layer_height,
+                layer_count=layer_count)
         layer_count += 1
         current_layer_height += layer_height
+    os.remove(scad_temp_file)
 
 def create_slice(
     output_type,
@@ -98,48 +105,46 @@ def create_slice(
     layer_count
 ):
     out_model_file_name = make_output_file_name(
-        output_type, model_name, layer_count );
+        output_type, model_name, layer_count)
 
-    print "    Outputting to " + out_model_file_name
+    print("    Outputting to " + out_model_file_name)
+    with open(tmp_file, 'w') as out_scad:
+        out_scad.write('projection( cut = true )'
+                       ' translate( v = [ 0, 0, -' + str(slice_height) + ' ] )'
+                       ' import( "' + os.path.abspath(model_name) + '" ); ')
 
-    out_scad = file( tmp_file, 'w' )
-    out_scad.write( 'projection( cut = true )'
-        ' translate( v = [ 0, 0, -' + str( slice_height ) + ' ] )'
-        ' import( "' + os.path.abspath( model_name ) + '" ); ' )
-    out_scad.close()
+    run_openscad(out_model_file_name, tmp_file)
 
-    run_openscad( out_model_file_name, tmp_file );
 
-def make_output_file_name( output_type, model_name, layer_count ):
-    # TODO
-    # Pad layer_count
-    # Strip off old file extension
-    file_name = model_name + '_' + str( layer_count ) + '.' + output_type
+def make_output_file_name(output_type, model_name, layer_count):
+    stripped_model_name, _ = os.path.splitext(model_name)
+    file_name = stripped_model_name + '_' + str(layer_count).zfill(4) + '.' + output_type
     return file_name
 
-def run_openscad( out_model_file_name, scad_file ):
+
+def run_openscad(out_model_file_name, scad_file):
     subprocess.call([
         'openscad',
-        '-o', out_model_file_name,
+        '-o',
+        out_model_file_name,
         scad_file
     ])
 
-args = parse_args()
-print "Input file: " + args.input
-print "Output type: " + args.output_type
-print "Start slicing height: " + str( args.start_height )
-print "End slicing height: " + str( args.end_height )
-print "Layer height: " + str( args.layer_height )
-print ""
-print "=" * 10
-print ""
 
-scad_file_name = get_scad_tmp_file()
-slice_model(
-        output_type = args.output_type,
-        model_name = args.input,
-        tmp_file = scad_file_name,
-        start_height = args.start_height,
-        layer_height = args.layer_height,
-        end_height = args.end_height )
-os.unlink( scad_file_name )
+if __name__ == '__main__':
+    args = parse_args()
+    print("Input file: " + args.input)
+    print("Output type: " + args.output_type)
+    print("Start slicing height: " + str(args.start_height))
+    print("End slicing height: " + str(args.end_height))
+    print("Layer height: " + str(args.layer_height))
+    print("")
+    print("=" * 10)
+    print("")
+
+    slice_model(
+            output_type=args.output_type,
+            model_name=args.input,
+            start_height=args.start_height,
+            layer_height=args.layer_height,
+            end_height=args.end_height)


### PR DESCRIPTION
Using regular OS functions to create and delete temp file
Using "with open" to write the temp openscad commands
Added extension stripping from filename and padding up to 4 places to output name
added if main to run
updated print statements for python 3+ compatibility
removed need for tempfile lib
changed formatting